### PR TITLE
learn: chapter 4, creating layouts and pages

### DIFF
--- a/app/dashboard/customers/page.tsx
+++ b/app/dashboard/customers/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>Customers Page</p>;
+}

--- a/app/dashboard/invoices/page.tsx
+++ b/app/dashboard/invoices/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>Invoices Page</p>;
+}

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -1,0 +1,12 @@
+import SideNav from '@/app/ui/dashboard/sidenav';
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex h-screen flex-col md:flex-row md:overflow-hidden">
+      <div className="w-full flex-none md:w-64">
+        <SideNav />
+      </div>
+      <div className="flex-grow p-6 md:overflow-y-auto md:p-12">{children}</div>
+    </div>
+  );
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>Dashboard Page</p>;
+}


### PR DESCRIPTION
# このPRでやったこと

Next.jsにおけるルーティングとレイアウトについて学んだ。
https://nextjs.org/learn/dashboard-app/creating-layouts-and-pages#creating-the-dashboard-page

# ルーティング

Next.jsは、ディレクトリを作り、その中に`page.tsx`という予約された名前のJSXファイルを作ると、それがルーティングのキーワードとなり、そのパスのURLにアクセスできるようになる。Learn Next.jsでは`dashboard`ディレクトリを作成して、その中に`page.tsx`ファイルを作ることで、`/dashboard`にアクセスできるようにする手順をやった。また、`/dashboard/customers`や`/dashboard/invoices`というルートも作った。

これ自体は別に何も難しいことはない。そういうルールになっていますよというだけだ。

ちょっと面白いのは、Next.jsのApp Routerの場合はほぼ全てのファイルが`app`ディレクトリ以下に置かれていて、ルーティングに使われるものもそうでないものも一緒くたに置かれているところ。これは以前使ったことがあるNuxtや、App Router登場前に使われていたらしいPages Routerのものと結構感覚が異なる。以前の常識的なアーキテクチャは`pages`ディレクトリがあって、そこにはルーティングに関係するファイルだけを置くというのが定番だったので、面白い。

賛否両論ありそうな仕様ではあるが、結局のところ例えばCSSなども`pages`と`assets`ディレクトリの構成が全く同じだったりというのは良くある話で、`pages`をリネームして関連する他のディレクトリ構成も全部同じようにリネームする作業、みたいなのはよく発生していて面倒だったので、ディレクトリ構成をいちいち合わせなくて済むApp Routerは、個人的には好み。

# レイアウト

`page.tsx`と同様、予約された名前である`layout.tsx`を同じように作ることで、レイアウトファイルを定義することができる。このLearn Next.jsでは、`dashboard`ディレクトリに`layout.tsx`を作ることで、ダッシュボードで共通のレイアウトファイルを定義した。このレイアウトは、`dashboard`以下の`customers`や`invoices`のページにも、継承されて適用される。

また、このレイアウトはサイドナビゲーションが定義されているようなレイアウトだが、このサイド部分は1度しかレンダリングされず、例えば`customers`に移動したとしても、レンダリングされるのは`customers`の部分だけで、それによりパフォーマンスが良くなる。これを[partial rendering](https://nextjs.org/docs/app/building-your-application/routing/linking-and-navigating#3-partial-rendering)というらしい。

レイアウトも特に難しい話ではない。これもルーティングと同様、App Routerであることでどのレイアウトがどのパスで使われるのかが一目瞭然なので、分かりやすいと思う。Nuxtの場合は`layouts`ディレクトリにレイアウトファイルを置いておく必要があり、どのレイアウトがどのページで使われているのかは、`pages`内のファイルを見ないと分からなかった。